### PR TITLE
Bracketed Paste Mode workaround

### DIFF
--- a/.vimrc.common
+++ b/.vimrc.common
@@ -185,3 +185,19 @@ endif
 
 "au BufWriteCmd *.php call UpdateCtags()
 au BufNewFile,BufRead *.html set filetype=smarty
+
+" avoid line indentation caused by bracketed paste mode
+" on Mac OS X. Check setting for $TERM and set accordingly
+if &term =~ "xterm.*"
+    let &t_ti = &t_ti . "\e[?2004h"
+    let &t_te = "\e[?2004l" . &t_te
+    function XTermPasteBegin(ret)
+        set pastetoggle=<Esc>[201~
+        set paste
+        return a:ret
+    endfunction
+    map <expr> <Esc>[200~ XTermPasteBegin("i")
+    imap <expr> <Esc>[200~ XTermPasteBegin("")
+    cmap <Esc>[200~ <nop>
+    cmap <Esc>[201~ <nop>
+endif


### PR DESCRIPTION
Fixed line-by-line indentation of pasted content in terminal on Mac OS X.

Trying to paste content from the clipboard into vim (iterm2) resulted in every line being indented adding more indentation for each line. The root problem seems to be the bracketed paste mode, which enables the terminal emulator to tell the program connected to the tty when the user pastes text, so that the program won’t interpret it as editing commands. Programs that support it send the terminal an escape sequence to enable this mode, in which the terminal surrounds pasted text with a pair of escape sequences that identify the start and end.
